### PR TITLE
remove pulsarClient from produceMessageOptions

### DIFF
--- a/pulsar/connector/producer.go
+++ b/pulsar/connector/producer.go
@@ -23,10 +23,9 @@ func CreateProducer(pulsarClient pulsar.Client, topic string) (pulsar.Producer, 
 }
 
 type produceMessageOptions struct {
-	msgToSend    interface{}
-	pulsarClient pulsar.Client
-	ctx          context.Context
-	properties   map[string]string
+	msgToSend  interface{}
+	ctx        context.Context
+	properties map[string]string
 }
 
 type ProduceMessageOption func(*produceMessageOptions)
@@ -40,12 +39,6 @@ func WithContext(ctx context.Context) ProduceMessageOption {
 func WithMessageToSend(msgToSend interface{}) ProduceMessageOption {
 	return func(o *produceMessageOptions) {
 		o.msgToSend = msgToSend
-	}
-}
-
-func WithPulsarClient(pulsarClient pulsar.Client) ProduceMessageOption {
-	return func(o *produceMessageOptions) {
-		o.pulsarClient = pulsarClient
 	}
 }
 

--- a/pulsar/connector/suite_test.go
+++ b/pulsar/connector/suite_test.go
@@ -108,7 +108,7 @@ func (suite *MainTestSuite) TestProduceMessage() {
 
 	//produce message
 	msg := "test message"
-	if err := ProduceMessage(producer, WithMessageToSend(msg), WithContext(context.Background()), WithPulsarClient(suite.pulsarClient)); err != nil {
+	if err := ProduceMessage(producer, WithMessageToSend(msg), WithContext(context.Background())); err != nil {
 		suite.FailNow("failed to produce message", err.Error())
 	}
 }


### PR DESCRIPTION
producer is initialized with pulsarClient, so no need to pass it every time we produce a message