### PR TITLE
Handle re-consume  later

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pulsar/connector/client.go
+++ b/pulsar/connector/client.go
@@ -20,7 +20,8 @@ const (
 	tenantsPath          = adminPath + "/tenants"
 	namespacesPath       = adminPath + "/namespaces"
 
-	dlqNamespaceSuffix = "-dlqs"
+	dlqNamespaceSuffix   = "-dlqs"
+	retryNamespaceSuffix = "-retry"
 )
 
 type PulsarClientOptions struct {
@@ -130,6 +131,11 @@ func NewClient(options ...func(*PulsarClientOptions)) (Client, error) {
 		log.Printf("creating dlq namespace %s\n", dlqNamespacePath)
 		if initErr = pulsarAdminRequest(http.MethodPut, dlqNamespacePath, nil); initErr != nil {
 			return nil, fmt.Errorf("failed to create dlq namespace: %w", initErr)
+		}
+		retryNamespacePath := namespacePath + retryNamespaceSuffix
+		log.Printf("creating retry namespace %s\n", retryNamespacePath)
+		if initErr = pulsarAdminRequest(http.MethodPut, retryNamespacePath, nil); initErr != nil {
+			return nil, fmt.Errorf("failed to create retry namespace: %w", initErr)
 		}
 	}
 	return pulsarClient, nil

--- a/pulsar/connector/dlq.go
+++ b/pulsar/connector/dlq.go
@@ -7,10 +7,11 @@ import (
 	"github.com/apache/pulsar-client-go/pulsar"
 )
 
-func NewDlq(tenant, namespace string, topic TopicName, maxDeliveryAttempts uint32) *pulsar.DLQPolicy {
+func NewDlq(tenant, namespace string, topic TopicName, maxDeliveryAttempts uint32, retryTopic string) *pulsar.DLQPolicy {
 	return &pulsar.DLQPolicy{
-		MaxDeliveries:   maxDeliveryAttempts,
-		DeadLetterTopic: BuildPersistentTopic(tenant, namespace, topic+"-dlq"),
+		MaxDeliveries:    maxDeliveryAttempts,
+		RetryLetterTopic: retryTopic,
+		DeadLetterTopic:  BuildPersistentTopic(tenant, namespace, topic+"-dlq"),
 		ProducerOptions: pulsar.ProducerOptions{
 			//TODO: OTL
 			//		Interceptors: tracer.NewProducerInterceptors(ctx),

--- a/pulsar/connector/suite_test.go
+++ b/pulsar/connector/suite_test.go
@@ -118,7 +118,9 @@ func (suite *MainTestSuite) TearDownTest() {
 					return err
 				}
 			}
-			consumer.Ack(msg)
+			if err := consumer.Ack(msg); err != nil {
+				suite.FailNow(err.Error())
+			}
 			if suite.failOnUnconsummedMessages {
 				return fmt.Errorf("unconsumed message topic:%s \npayload:%s \nproperites:%v", msg.Topic(), msg.Payload(), msg.Properties())
 			}
@@ -134,7 +136,9 @@ func (suite *MainTestSuite) TearDownTest() {
 					return err
 				}
 			}
-			dlqConsumer.Ack(msg)
+			if err := dlqConsumer.Ack(msg); err != nil {
+				suite.FailNow(err.Error())
+			}
 			if suite.failOnUnconsummedMessages {
 				return fmt.Errorf("unconsumed message topic:%s \npayload:%s \nproperites:%v", msg.Topic(), msg.Payload(), msg.Properties())
 			}
@@ -288,7 +292,9 @@ func consumeMessages[P TestPayload](suite *MainTestSuite, ctx context.Context, c
 		}
 		actualPayloads[payload.GetId()] = payload
 		fmt.Printf("%s: Ack() - ID %s", consumerId, payload.GetId())
-		consumer.Ack(msg)
+		if err := consumer.Ack(msg); err != nil {
+			suite.FailNow(err.Error())
+		}
 	}
 	return actualPayloads
 }
@@ -427,7 +433,9 @@ func (suite *MainTestSuite) TestReconsumeLaterWithNacks() {
 	if err != nil {
 		suite.FailNow(err.Error(), "reconsume payload")
 	}
-	dlqConsumer.Ack(msg)
+	if err := dlqConsumer.Ack(msg); err != nil {
+		suite.FailNow(err.Error())
+	}
 	testMsg(msg)
 	//fail on test teardown if there are unconsumed messages
 	suite.failOnUnconsummedMessages = true
@@ -502,7 +510,9 @@ func (suite *MainTestSuite) TestReconsumeLaterMaxAttemps() {
 	if err != nil {
 		suite.FailNow(err.Error(), "reconsume payload")
 	}
-	dlqConsumer.Ack(msg)
+	if err := dlqConsumer.Ack(msg); err != nil {
+		suite.FailNow(err.Error())
+	}
 	testMsg(msg)
 	//fail on test teardown if there are unconsumed messages
 	suite.failOnUnconsummedMessages = true
@@ -565,7 +575,9 @@ func (suite *MainTestSuite) TestReconsumeLater() {
 	}
 	testMsg(msg)
 	suite.False(consumer.IsReconsumable(msg), "expect message not to be reconsumable")
-	consumer.Ack(msg)
+	if err := consumer.Ack(msg); err != nil {
+		suite.FailNow(err.Error())
+	}
 	//fail on test teardown if there are unconsumed messages
 	suite.failOnUnconsummedMessages = true
 
@@ -636,7 +648,9 @@ func (suite *MainTestSuite) TestReconsumeLaterWithDuration() {
 	if err != nil {
 		suite.FailNow(err.Error(), "reconsume payload")
 	}
-	dlqConsumer.Ack(msg)
+	if err := dlqConsumer.Ack(msg); err != nil {
+		suite.FailNow(err.Error())
+	}
 	testMsg(msg)
 
 	//fail on test teardown if there are unconsumed messages
@@ -700,7 +714,9 @@ func (suite *MainTestSuite) TestSafeReconsumeLaterWithDuration() {
 	//reconsume anyway
 	sent := consumer.SafeReconsumeLater(msg, time.Millisecond*5)
 	suite.False(sent, "expect reconsume to send message")
-	consumer.Ack(msg)
+	if err := consumer.Ack(msg); err != nil {
+		suite.FailNow(err.Error())
+	}
 	//fail on test teardown if there are unconsumed messages
 	suite.failOnUnconsummedMessages = true
 }


### PR DESCRIPTION
#### Pulsar default behavior is to redeliver the message until it reached the number in MaxRedeliveries option and then move it to the DLQ
So for instance if MaxRedeliveries  is set to 2 
A message will get to the DLQ when for instance it is:
Called with ReconsumeLater 3 times 
or Re-consumed two times and n-acked two time 

#### Support ReconsumeLaterDLQSafe  & retry by duration for clients (e.g. ingesters) that need to retry for some time and not loose the message to the DLQ if retries were not successful 

1. Set re-consume topic to namespace `<namespace>-retry `
2. Add ability to re-consume by max duration of time instead of max redeliveries
3. Add ReconsumeLaterDLQSafe  that will not sent the message and return false if re-consume attempts exceeded (by duration or redeliveries count) so client can avoid the dlq and handle the message if possible 

