### PR TITLE
Add PolicyGUIDToName field to RuntimeIncidentIngesterOnFinishedMessag…

### DIFF
--- a/pulsar/common/kdr/datastructures.go
+++ b/pulsar/common/kdr/datastructures.go
@@ -21,6 +21,7 @@ type RuntimeIncidentIngesterOnFinishedMessage struct {
 	Severity            string                       `json:"severity"`
 	Resource            identifiers.PortalDesignator `json:"resource"` // Pod, Node, Workload, Namespace, Cluster, etc.
 	Response            *RuntimeIncidentResponse     `json:"response,omitempty"`
+	PolicyGUIDToName    map[string]string            `json:"policyGUIDToName"`
 }
 
 type RuntimeIncidentResponse struct {


### PR DESCRIPTION
…e struct

- Introduced a new field 'PolicyGUIDToName' to the RuntimeIncidentIngesterOnFinishedMessage data structure to map policy GUIDs to their corresponding names, enhancing the detail and usability of incident messages.