### PR TITLE
chore: bump armoapi-go for reason codes, Error field, ReasonFriendlyText

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/apache/pulsar-client-go v0.16.0
-	github.com/armosec/armoapi-go v0.0.690
+	github.com/armosec/armoapi-go v0.0.694
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/apache/pulsar-client-go v0.16.0 h1:SnmGzqcTu6WpK4D6I2Jdwe/VCFkMUk516O
 github.com/apache/pulsar-client-go v0.16.0/go.mod h1:ow9PhLoGUY6ncrKOtjnWeJycFnTKOwrIV39j3kNV54M=
 github.com/ardielle/ardielle-go v1.5.2 h1:TilHTpHIQJ27R1Tl/iITBzMwiUGSlVfiVhwDNGM3Zj4=
 github.com/ardielle/ardielle-go v1.5.2/go.mod h1:I4hy1n795cUhaVt/ojz83SNVCYIGsAFAONtv2Dr7HUI=
-github.com/armosec/armoapi-go v0.0.690 h1:TQOWPLrTHJiIlOTK06nQ/tPnSJ3O6ImMlQtptm+D+/o=
-github.com/armosec/armoapi-go v0.0.690/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.694 h1:LDScWAzikv7mJdDhO+VM0DfNoMhQbhA6do6LWXHRIQs=
+github.com/armosec/armoapi-go v0.0.694/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-k8s-go v0.0.30 h1:Gj8MJck0jZPSLSq8ZMiRPT3F/laOYQdaLxXKKcjijt4=


### PR DESCRIPTION
## Summary

Bump armoapi-go to pick up scan failure notification enhancements from [armosec/armoapi-go#625](https://github.com/armosec/armoapi-go/pull/625):

- 12 `Reason*` constants (enum-like codes for scan failure notifications)
- `Error` field on `ScanFailureReport` (R&D debugging, not user-facing)
- `ReasonFriendlyText()` for UNS notification rendering
- `ReasonScannerOOMKilled` and `ReasonScanTimeout` for sidecar-specific failures

Since `ScanFailureOnFinishedMessage` embeds `ScanFailureReport`, this bump ensures the `Error` field flows through event-ingester to UNS.

## Related

- Jira: [SUB-7074](https://cyberarmor-io.atlassian.net/browse/SUB-7074)
- armoapi-go: [armosec/armoapi-go#625](https://github.com/armosec/armoapi-go/pull/625)
- kubevuln: [kubescape/kubevuln#334](https://github.com/kubescape/kubevuln/pull/334)
- node-agent: [kubescape/node-agent#760](https://github.com/kubescape/node-agent/pull/760)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to a newer release to keep libraries current. This change refreshes underlying tooling for improved stability, maintenance, and future compatibility; it does not alter public APIs or exported behavior and has no user-facing feature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->