### PR TITLE
feat: add hot CVE topic constants (SUB-7201)

### DIFF
--- a/pulsar/common/topics.go
+++ b/pulsar/common/topics.go
@@ -45,6 +45,10 @@ const (
 
 	CloudHostAgentKeepAliveTopic = "cloud-host-agent-keep-alive-v1"
 
+	// hot CVE topics
+	HotCVEDefinitionsTopic     = "hot-cve-definitions-v1"
+	HotCVEOnFinishPulsarTopic  = "hot-cve-on-finish-v1"
+
 	// scan failure topic
 	ScanFailureTopic = "scan-failure-v1"
 )


### PR DESCRIPTION
## Summary

Add shared Pulsar topic constants for hot CVE feature:

- `HotCVEDefinitionsTopic` (`hot-cve-definitions-v1`) — admin API publishes hot CVE definitions, k8s-object ingester consumes
- `HotCVEOnFinishPulsarTopic` (`hot-cve-on-finish-v1`) — ingester publishes after processing, UNS consumes for notifications

These replace hardcoded string literals in cadashboardbe and event-ingester-service.

SUB-7201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hot CVE definitions and event notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->