### PR TITLE
feat: add HotCVEOnFinishedMessageTypeProp constant

### DIFF
--- a/pulsar/common/topics.go
+++ b/pulsar/common/topics.go
@@ -46,8 +46,9 @@ const (
 	CloudHostAgentKeepAliveTopic = "cloud-host-agent-keep-alive-v1"
 
 	// hot CVE topics
-	HotCVEDefinitionsTopic     = "hot-cve-definitions-v1"
-	HotCVEOnFinishPulsarTopic  = "hot-cve-on-finish-v1"
+	HotCVEDefinitionsTopic                = "hot-cve-definitions-v1"
+	HotCVEOnFinishPulsarTopic             = "hot-cve-on-finish-v1"
+	HotCVEOnFinishedMessageTypeProp       = "HotCVEOnFinished" // MsgPropMessageType value for hot CVE on-finish messages on k8s-objects-finished-v1
 
 	// scan failure topic
 	ScanFailureTopic = "scan-failure-v1"


### PR DESCRIPTION
Used as MsgPropMessageType value when publishing HotCVEOnFinishedMessage to k8s-objects-finished-v1 topic. UNS uses this to route messages to the hot CVE notification handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend infrastructure to improve notification message handling capabilities for the vulnerability management system, including better support for tracking notification completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->