### PR TITLE
feat: add IncidentClassificationRequestTopic constant

### DIFF
--- a/pulsar/common/topics.go
+++ b/pulsar/common/topics.go
@@ -52,4 +52,7 @@ const (
 
 	// scan failure topic
 	ScanFailureTopic = "scan-failure-v1"
+
+	// incident classification topics
+	IncidentClassificationRequestTopic = "incident-classification-request-v1"
 )


### PR DESCRIPTION
Adds `IncidentClassificationRequestTopic` constant for the incident AI classification Pulsar topic, used by cadashboardbe's reclassify-ai endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident classification request messaging support to enable new system capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->