### PR TITLE
feat(ai-sandbox): add apply-ai-sandbox user-input command

### DIFF
--- a/pulsar/common/userinput/commands.go
+++ b/pulsar/common/userinput/commands.go
@@ -103,6 +103,7 @@ const (
 
 	UserInputCommandApplyNetworkPolicy  = UserInputCommand("apply-network-policy")
 	UserInputCommandApplySeccompProfile = UserInputCommand("apply-seccomp-profile")
+	UserInputCommandApplyAiSandbox      = UserInputCommand("apply-ai-sandbox")
 
 	UserInputCommandDeleteSavedFilter = UserInputCommand("delete-saved-filter")
 	UserInputCommandUpdateSavedFilter = UserInputCommand("update-saved-filter")


### PR DESCRIPTION
## What
Adds `UserInputCommandApplyAiSandbox = "apply-ai-sandbox"` to `pulsar/common/userinput`.

## Why
Base contract for the AI-sandbox **enable** (add-to-sandbox) write-path. It mirrors the existing `apply-seccomp-profile` / `apply-network-policy` commands:
- **cadashboardbe** produces it on the `user-input` topic (payload `{resourceHash}`).
- **event-ingester-service** consumes it, resolves the workload, and applies the `kubescape.io/sandbox=true` pod-template label via the synchronizer.

## Notes
Pure constant addition — no behavior change in this repo. Consumers (cadashboardbe, event-ingester-service) pin to this commit until release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new user input command option, `apply-ai-sandbox`, to the available command set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->