### PR TITLE
feat(pulsar): add CloudAiSandboxHeartbeatTopic constant

### DIFF
--- a/pulsar/common/topics.go
+++ b/pulsar/common/topics.go
@@ -45,10 +45,12 @@ const (
 
 	CloudHostAgentKeepAliveTopic = "cloud-host-agent-keep-alive-v1"
 
+	CloudAiSandboxHeartbeatTopic = "ai-sandbox-heartbeat-v1"
+
 	// hot CVE topics
-	HotCVEDefinitionsTopic                = "hot-cve-definitions-v1"
-	HotCVEOnFinishPulsarTopic             = "hot-cve-on-finish-v1"
-	HotCVEOnFinishedMessageTypeProp       = "HotCVEOnFinished" // MsgPropMessageType value for hot CVE on-finish messages on k8s-objects-finished-v1
+	HotCVEDefinitionsTopic          = "hot-cve-definitions-v1"
+	HotCVEOnFinishPulsarTopic       = "hot-cve-on-finish-v1"
+	HotCVEOnFinishedMessageTypeProp = "HotCVEOnFinished" // MsgPropMessageType value for hot CVE on-finish messages on k8s-objects-finished-v1
 
 	// scan failure topic
 	ScanFailureTopic = "scan-failure-v1"


### PR DESCRIPTION
Adds the Pulsar topic constant `CloudAiSandboxHeartbeatTopic = "ai-sandbox-heartbeat-v1"` used by the new AI-Sandbox instance-heartbeat flow (careportsreceiver producer → event-ingester consumer), mirroring `CloudHostAgentKeepAliveTopic`.

Consumed by (branch-pinned to this commit until merged):
- careportsreceiver — heartbeat intake endpoint (`/cloud/v1/aiSandbox/heartbeat`)
- event-ingester-service — heartbeat consumer → `ai_sandbox_instances.last_seen`

Jira: SUB-7543 (part of SUB-7536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new public topic: `ai-sandbox-heartbeat-v1`.
* **Style**
  * Reformatted existing topic constant declarations for consistency; no behavior changes to existing topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->