### PR TITLE
feat(ai-sandbox): add remove-ai-sandbox user-input command (SUB-7442)

### DIFF
--- a/pulsar/common/userinput/commands.go
+++ b/pulsar/common/userinput/commands.go
@@ -104,6 +104,7 @@ const (
 	UserInputCommandApplyNetworkPolicy  = UserInputCommand("apply-network-policy")
 	UserInputCommandApplySeccompProfile = UserInputCommand("apply-seccomp-profile")
 	UserInputCommandApplyAiSandbox      = UserInputCommand("apply-ai-sandbox")
+	UserInputCommandRemoveAiSandbox     = UserInputCommand("remove-ai-sandbox")
 
 	UserInputCommandDeleteSavedFilter = UserInputCommand("delete-saved-filter")
 	UserInputCommandUpdateSavedFilter = UserInputCommand("update-saved-filter")


### PR DESCRIPTION
## What

Adds the `UserInputCommandRemoveAiSandbox = "remove-ai-sandbox"` user-input command constant — the counterpart of `apply-ai-sandbox`, for the AI-sandbox **remove from sandbox** write-path.

## Why

Product decision (SUB-7442, shared-designs-and-docs #112): the sandbox lifecycle gains a reversible "remove" action. cadashboardbe publishes this command on the `user-input` topic; event-ingester consumes it and deletes the `kubescape.io/sandbox` pod-template marker.

## Downstream

This is the root dependency for the remove flow. Once merged and tagged, bump the pin in **cadashboardbe** and **event-ingester-service** (`go get github.com/kubescape/messaging@<tag>`) — their PRs reference this constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: plan,pr_comments | cmds: /review_plan,/compact,/model,/design-consent,/design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new user input command for removing the AI sandbox, expanding the available command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->